### PR TITLE
workflows: sync runlnd readme

### DIFF
--- a/.github/workflows/doc-sync.yaml
+++ b/.github/workflows/doc-sync.yaml
@@ -41,6 +41,10 @@ jobs:
             org: lightninglabs
             src: docs
             dest: docs/pool
+          - repo: run-lnd
+            org: alexbosworth
+            src: README.md
+            dest: docs/run-lnd
 
     steps:
       - name: Checkout docs.lightning.engineering repo


### PR DESCRIPTION
Pull Request Checklist
- [ ] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
