### PR TITLE
workflows: add /* to directories to prevent extra sub dir

### DIFF
--- a/.github/workflows/doc-sync.yaml
+++ b/.github/workflows/doc-sync.yaml
@@ -23,23 +23,23 @@ jobs:
         include:
           - repo: lnd
             org: lightningnetwork
-            src: docs
+            src: docs/*
             dest: docs/lnd
           - repo: lightning-terminal
             org: lightninglabs
-            src: doc
+            src: doc/*
             dest: docs/lit
           - repo: loop 
             org: lightninglabs
-            src: docs
+            src: docs/*
             dest: docs/loop
           - repo: faraday 
             org: lightninglabs
-            src: docs
+            src: docs/*
             dest: docs/faraday
           - repo: pool 
             org: lightninglabs
-            src: docs
+            src: docs/*
             dest: docs/pool
           - repo: run-lnd
             org: alexbosworth


### PR DESCRIPTION
Pull Request Checklist
- [ ] The documents updated are not in the `docs/` directory. These files are
  synced from upstream repositories ([lnd](https://github.com/lightningnetwork/lnd), [lit](https://github.com/lightninglabs/lightning-terminal), [loop](https://github.com/lightninglabs/loop), [pool](https://github.com/lightninglabs/pool) and [faraday](https://github.com/lightninglabs/faraday)), and 
  should be updated in their parent repo.
